### PR TITLE
Use music-metadata for duration calculation

### DIFF
--- a/generator/src/semantic-machine.ts
+++ b/generator/src/semantic-machine.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as _ from 'lodash';
-import * as wavinfo from 'wav-file-info';
+import * as musicMetadata from 'music-metadata';
 import { SuperDymoStore, DymoGenerator, DymoTemplates, uris, forAll } from 'dymo-core';
 import { DymoWriter } from './dymo-writer';
 import { SERVER_PATH } from './server';
@@ -241,13 +241,13 @@ async function addParamDependentType(dymoType: string, paramType: string) {
   return type;
 }
 
-async function getDuration(audio: string): Promise<any> {
-  return new Promise((resolve, reject) => {
-    wavinfo.infoByFilename(audio.replace('.m4a','.wav'), (err, info) => {
-      if (err) reject(err);
-      resolve(info.duration);
-    });
-  })
+/**
+ * Extract audio duration of provided audio file
+ * @param audio {string} path to audio file
+ * @return {Promise<number>} duration in seconds
+ */
+async function getDuration(audio: string): Promise<number> {
+  return musicMetadata.parseFile(audio, {duration: true}).then(metadata => metadata.format.duration);
 }
 
 /*async function addMaterial(parent: string, searchStrings: string[][], excludeStrings: string[] = [], dymoType = uris.MULTI_SELECTION) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "core-js": "^2.5.4",
     "dymo-player": "^0.3.4",
     "lodash": "^4.17.15",
+    "music-metadata": "^4.5.3",
     "rxjs": "~6.5.1",
     "stream": "0.0.2",
     "tslib": "^1.9.0",


### PR DESCRIPTION
Would you like to give [music-metadata](https://github.com/Borewit/music-metadata) a try?

It is written in TypeScript as well, should work with any audio file you can find.

I look forward to hear your feedback.